### PR TITLE
Repair windows build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - cython
     - pkg-config  # [not win]
     - msinttypes  # [win and py27]
+    - curl  # [win]
     - ffmpeg 2.8.6
   run:
     - python


### PR DESCRIPTION
There was an issue introduced with the previous CI regeneration. Apparently curl needs to be added as a dependency for the appveyor builds.